### PR TITLE
Fix SSH dimension parsing

### DIFF
--- a/server/interface-ssh.go
+++ b/server/interface-ssh.go
@@ -274,6 +274,10 @@ func (ssh_interface *Interface_SSH) Stop() error {
 
 // parseDims parses terminal dimensions from the SSH payload.
 func ParseDims(b []byte) (width, height int) {
+	if len(b) < 8 {
+		return 0, 0
+	}
+
 	width = int(b[0])<<24 | int(b[1])<<16 | int(b[2])<<8 | int(b[3])
 	height = int(b[4])<<24 | int(b[5])<<16 | int(b[6])<<8 | int(b[7])
 	return width, height

--- a/server/interface-ssh_test.go
+++ b/server/interface-ssh_test.go
@@ -1,0 +1,40 @@
+package main
+
+import "testing"
+
+func TestParseDims(t *testing.T) {
+	tests := []struct {
+		name       string
+		payload    []byte
+		wantWidth  int
+		wantHeight int
+	}{
+		{
+			name:       "Valid payload",
+			payload:    []byte{0, 0, 0, 80, 0, 0, 0, 24},
+			wantWidth:  80,
+			wantHeight: 24,
+		},
+		{
+			name:       "Short payload",
+			payload:    []byte{1, 2, 3},
+			wantWidth:  0,
+			wantHeight: 0,
+		},
+		{
+			name:       "Empty payload",
+			payload:    nil,
+			wantWidth:  0,
+			wantHeight: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w, h := ParseDims(tt.payload)
+			if w != tt.wantWidth || h != tt.wantHeight {
+				t.Errorf("ParseDims(%v) = (%d,%d), want (%d,%d)", tt.payload, w, h, tt.wantWidth, tt.wantHeight)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- guard against short SSH payloads in `ParseDims`
- add unit tests for the new behavior

## Testing
- `go test ./...` *(fails: downloads toolchain, network forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684362cc1d9c8331a9280d3ade09f38c