### PR TITLE
Fix initializing spelling in logs

### DIFF
--- a/server/game.go
+++ b/server/game.go
@@ -58,7 +58,7 @@ type Game struct {
 
 func NewGame(globalCtx context.Context, config *Configuration) (*Game, error) {
 
-	Logger.Info("New Game...Initalizing Game...")
+	Logger.Info("New Game...Initializing Game...")
 
 	ctx, cancel := context.WithCancel(globalCtx)
 

--- a/server/room.go
+++ b/server/room.go
@@ -71,7 +71,7 @@ type RoomData struct {
 
 func NewRoom(ctx context.Context, roomID int64, area, title, description string, persistent bool, scriptID string) *Room {
 
-	Logger.Debug("New Room...Initalizing Room...", "roomID", roomID, "persistent", persistent, "scriptID", scriptID)
+	Logger.Debug("New Room...Initializing Room...", "roomID", roomID, "persistent", persistent, "scriptID", scriptID)
 
 	now := time.Now()
 


### PR DESCRIPTION
## Summary
- correct `Initializing` spelling in `NewGame` and `NewRoom` logs

## Testing
- `go test ./...` *(fails: toolchain download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684365a704588331bc0ebbb1cab96b66