### PR TITLE
Fix SendRoomMessage comment

### DIFF
--- a/server/exit_test.go
+++ b/server/exit_test.go
@@ -350,7 +350,7 @@ func TestSendArrivalMessage(t *testing.T) {
 					tt.name == "Arriving character excluded from message" {
 					// The arriving character's mock would have been created above
 					// We can't easily check it here due to the test structure
-					// but the real SendRoomMessageExcept function handles the exclusion
+					// but the real SendRoomMessage function handles the exclusion
 				}
 			}
 		})

--- a/server/room.go
+++ b/server/room.go
@@ -150,7 +150,7 @@ func (r *Room) GetScriptID() string {
 	return r.scriptID
 }
 
-// SendRoomMessageExcept sends a message to all characters in a room except one
+// SendRoomMessage sends a message to all characters in a room except one
 func SendRoomMessage(room *Room, message string, except *Character) {
 	if room == nil {
 		return


### PR DESCRIPTION
## Summary
- fix comment above `SendRoomMessage`
- update tests to refer to `SendRoomMessage`

## Testing
- `go test ./...` *(fails: toolchain download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684365ac36f48331b72cab6ba59cc742